### PR TITLE
[DevOps] Init integration tests and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# NPM
 node_modules/
+
+# Playwright Info
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# Environment Variables
+.env

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
 - Ensure that npm is installed
 - Ensure that you have cloned the Site repository in a separate folder with `git clone https://github.com/LetsMesh/Site.git` and are able to run it with `pipenv shell` and `python manage.py runserver`
 - Although not strictly necessary, you may want to install the "Playwright Test for VSCode" extension
+- More info for Playwright can be foun in then [Playwright documentation](https://playwright.dev/docs/intro).
 
 ## Repository Setup
 - Clone this repository using `git clone https://github.com/LetsMesh/IntegrationTests.git`
@@ -26,6 +27,9 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
 ## Running Tests
 - You can run the following commands/follow these patterns to run tests
   - `npx playwright test` to run all tests.
+  - `npx playwright test example.spec.ts` to run all tests in a specific file, such as running all tests in `example.spec.ts` file.
+  - `npx playwright test tests/example/` to run all tests in a specific folder, such as running all tests in the `examples` folder.
+  - ... and many other ways you can find on the [Playwright documentation for running tests](https://playwright.dev/docs/running-tests).
 
 ## Writing Tests
 - TODO

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# IntegrationTests
-Repository for hosting integration tests to test the Lets Mesh website. 
+# Integration Tests
+Repository for hosting end-to-end and integration tests for the LetsMesh website. 
+
+## Prerequisites
+- Ensure that npm is installed
+- Ensure that you have cloned the Site repository in a separate folder with `git clone https://github.com/LetsMesh/Site.git`
+- Although not strictly necessary, you may want to install the "Playwright Test for VSCode" extension
+
+## Repository Setup
+- Clone this repository using `git clone https://github.com/LetsMesh/IntegrationTests.git`
+- Run `npm install` to install all required packages from `package.json`
+
+## Repository Structure
+- The Integration Tests repository contains:
+  - `.github` folder containing a `playwright.yml` file that will run your tests on commit/opening a PR.
+  - `node_modules` folder containing installed npm packages.
+  - `playwright-report` will only appear after running tests, and will contain Playwright reporters that detail the last finished tests and print failures when they occur.
+  - `test-results` will contain test artifacts such as screenshots, videos, traces, or other relevant information gathered in specific tests that capture that information.
+  - `.gitignore` to tell git to not track certain files and folders that we don't want uploaded to the master repository.
+  - `package.json` and `package-lock.json` are versioning files that are used to install packages and track package versions for the repository.
+  - `playwright.config.ts` contains configuration details for the Playwright test suite.
+  - `README.md` is the file you are currently reading.
+
+## Running Tests
+- TODO
+
+## Writing Tests
+- TODO

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
 - Run `npm install` to install all required packages from `package.json`
 
 ## Repository Structure
-- The Integration Tests repository contains:
+- The Integration Tests repository contains (note that some files/folders are in the .gitignore so not all will appear on the remote repository):
   - `.github/workflows` folder containing a `playwright.yml` file that will run your tests on commit/opening a PR.
   - `node_modules` folder containing installed npm packages.
   - `playwright-report` will only appear after running tests, and will contain Playwright reporters that detail the last finished tests and print failures when they occur.
   - `test-results` will contain test artifacts such as screenshots, videos, traces, or other relevant information gathered in specific tests that capture that information.
-  - `test-examples` folder containing an example `.spec.ts` file that test a demo app.
+  - `tests-examples` folder containing an example `.spec.ts` file that test a demo app.
   - `tests` folder contains all test files, such as `example.spec.ts`
   - `.gitignore` to tell git to not track certain files and folders that we don't want uploaded to the master repository.
   - `package.json` and `package-lock.json` are versioning files that are used to install packages and track package versions for the repository.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
 
 ## Repository Structure
 - The Integration Tests repository contains:
-  - `.github` folder containing a `playwright.yml` file that will run your tests on commit/opening a PR.
+  - `.github/workflows` folder containing a `playwright.yml` file that will run your tests on commit/opening a PR.
   - `node_modules` folder containing installed npm packages.
   - `playwright-report` will only appear after running tests, and will contain Playwright reporters that detail the last finished tests and print failures when they occur.
   - `test-results` will contain test artifacts such as screenshots, videos, traces, or other relevant information gathered in specific tests that capture that information.
+  - `test-examples` folder containing an example `.spec.ts` file that test a demo app.
   - `tests` folder contains all test files, such as `example.spec.ts`
   - `.gitignore` to tell git to not track certain files and folders that we don't want uploaded to the master repository.
   - `package.json` and `package-lock.json` are versioning files that are used to install packages and track package versions for the repository.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
 
 ## Prerequisites
 - Ensure that npm is installed
-- Ensure that you have cloned the Site repository in a separate folder with `git clone https://github.com/LetsMesh/Site.git`
+- Ensure that you have cloned the Site repository in a separate folder with `git clone https://github.com/LetsMesh/Site.git` and are able to run it with `pipenv shell` and `python manage.py runserver`
 - Although not strictly necessary, you may want to install the "Playwright Test for VSCode" extension
 
 ## Repository Setup
 - Clone this repository using `git clone https://github.com/LetsMesh/IntegrationTests.git`
+- Place a copy of your `.env` file from the Site repository into this project, and follow the provided `template.env`, making sure to add the path to your local Site repository in the `SITE_PATH` variable.
 - Run `npm install` to install all required packages from `package.json`
 
 ## Repository Structure
@@ -16,13 +17,15 @@ Repository for hosting end-to-end and integration tests for the LetsMesh website
   - `node_modules` folder containing installed npm packages.
   - `playwright-report` will only appear after running tests, and will contain Playwright reporters that detail the last finished tests and print failures when they occur.
   - `test-results` will contain test artifacts such as screenshots, videos, traces, or other relevant information gathered in specific tests that capture that information.
+  - `tests` folder contains all test files, such as `example.spec.ts`
   - `.gitignore` to tell git to not track certain files and folders that we don't want uploaded to the master repository.
   - `package.json` and `package-lock.json` are versioning files that are used to install packages and track package versions for the repository.
   - `playwright.config.ts` contains configuration details for the Playwright test suite.
   - `README.md` is the file you are currently reading.
 
 ## Running Tests
-- TODO
+- You can run the following commands/follow these patterns to run tests
+  - `npx playwright test` to run all tests.
 
 ## Writing Tests
 - TODO

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "integrationtests",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.3.1"
+      },
       "devDependencies": {
         "@playwright/test": "^1.37.1"
       }
@@ -36,6 +39,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
       "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
       "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.37.1"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,9 @@ import { defineConfig, devices } from "@playwright/test";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+require("dotenv").config();
+
+const sitePath = process.env.SITE_PATH;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -68,10 +70,11 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: "npm run start",
-  //   url: "http://127.0.0.1:3000",
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  /* Run your local dev server before starting the tests, wait 20 seconds until timeout */
+  webServer: {
+    command: `cd ${sitePath} && pipenv run python manage.py runserver`,
+    url: "http://127.0.0.1:8000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 20 * 1000,
+  },
 });

--- a/template.env
+++ b/template.env
@@ -1,0 +1,15 @@
+# Create a new file called .env based on this template
+
+API_SECRET_KEY = 
+# Get the API Secret Key variable from a Current Sprint member
+
+DB_NAME = 
+DB_USER = 
+DB_PASSWORD =
+# Recommended to set DB_Name to "mesh"
+# DB_USER and DB_PASSWORD are the credentials used to login into the local mySQL instance
+
+PEPPER = 
+
+SITE_PATH = 
+# Set this to the local file path of the Site's root folder on your PC

--- a/template.env
+++ b/template.env
@@ -5,11 +5,16 @@ API_SECRET_KEY =
 
 DB_NAME = 
 DB_USER = 
-DB_PASSWORD =
+DB_PASSWORD = 
 # Recommended to set DB_Name to "mesh"
 # DB_USER and DB_PASSWORD are the credentials used to login into the local mySQL instance
 
 PEPPER = 
+
+BACKBLAZE_BUCKET_NAME = 
+BACKBLAZE_MASTER_KEY = 
+BACKBLAZE_APPLICATION_KEY = 
+# Ask Joseph | JRSiwiecki on Discord for these, used to upload images to Backblaze Bucket for image storage
 
 SITE_PATH = 
 # Set this to the local file path of the Site's root folder on your PC


### PR DESCRIPTION
Initialize playwright project, update README with most info necessary for repo, configure playwright to run the Mesh server from site repo, add .env for environment variables needed to allow playwright to run the Mesh server

TODO: Still need to add how to write tests (#17)